### PR TITLE
Add a docstring to the package itself

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var esprima = require('esprima')
 
 module.exports = function (f) {
+  "Interpret a string literal at the beginning of a function as its documentation."
+  
   if (typeof f !== 'function') {
     throw new TypeError('not a function')
   }


### PR DESCRIPTION
Because it would be so meta. And because you should document your code, yeah.
